### PR TITLE
Disable next/previous buttons when editing a card while in a study session

### DIFF
--- a/app/components/study-session.gts
+++ b/app/components/study-session.gts
@@ -16,6 +16,7 @@ interface StudySessionSignature {
 
 export default class StudySession extends Component<StudySessionSignature> {
   @tracked currentIndex = 0;
+  @tracked isEditing = false;
 
   @cached
   get cards() {
@@ -37,11 +38,21 @@ export default class StudySession extends Component<StudySessionSignature> {
   }
 
   get disablePreviousButton() {
-    return this.currentIndex === 0;
+    return this.isEditing || this.currentIndex === 0;
   }
 
   get disableNextButton() {
-    return this.currentIndex === this.cards.length - 1;
+    return this.isEditing || this.currentIndex === this.cards.length - 1;
+  }
+
+  @action
+  enteredEditMode() {
+    this.isEditing = true;
+  }
+
+  @action
+  exitedEditMode() {
+    this.isEditing = false;
   }
 
   @action
@@ -59,6 +70,8 @@ export default class StudySession extends Component<StudySessionSignature> {
 
     <CardComponent
       @card={{this.currentCard}}
+      @enteredEdit={{this.enteredEditMode}}
+      @exitedEdit={{this.exitedEditMode}}
       data-test-id={{this.currentCard.id}}
       {{onKey "ArrowLeft" this.goBack}}
       {{onKey "ArrowRight" this.goForward}}

--- a/mirage/factories/card.js
+++ b/mirage/factories/card.js
@@ -2,6 +2,6 @@ import { Factory } from 'miragejs';
 import { faker } from '@faker-js/faker';
 
 export default Factory.extend({
-  front: () => faker.lorem.words(),
-  back: () => faker.lorem.words(),
+  front: () => `FRONT: ${faker.lorem.words()}`,
+  back: () => `BACK: ${faker.lorem.words()}`,
 });

--- a/tests/acceptance/study-mode-test.js
+++ b/tests/acceptance/study-mode-test.js
@@ -10,7 +10,7 @@ module('Acceptance | study mode', function (hooks) {
     this.cards = this.server.createList('card', 15, { collection: this.collection });
   });
 
-  module('entire collection', function () {
+  module('for an entire collection', function () {
     test('it shows every card in the collection once', async function (assert) {
       await visit(`/collection/${this.collection.slug}/study`);
 
@@ -48,6 +48,19 @@ module('Acceptance | study mode', function (hooks) {
 
       await click('[data-test-previous]');
       assert.strictEqual(cardsShown[1], currentCardId(), 'moving "previous" displays last-shown card');
+    });
+
+    test('cannot navigate back and forth while editing a card', async function (assert) {
+      await visit(`/collection/${this.collection.slug}/study`);
+
+      // advance to not be on the first card, so we can check both "Back" and "Next" states
+      await click('[data-test-next]');
+
+      // enter "edit" mode for the current card
+      await click('[data-test-edit-button]');
+
+      assert.dom('[data-test-next]').isDisabled('"next" button is disabled while in edit mode');
+      assert.dom('[data-test-previous]').isDisabled('"back" button is disabled while in edit mode');
     });
   });
 


### PR DESCRIPTION
Fixes part of #49 